### PR TITLE
Revert "use pull_request_target"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
   push:


### PR DESCRIPTION
Reverts guardrail-dev/guardrail-sample-maven-dropwizard#59

pull_request_target might be dangerous. I am reverting to pull_request

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
